### PR TITLE
Implement spatial map overhaul for PWA

### DIFF
--- a/pwa/src/components/MapCanvas.tsx
+++ b/pwa/src/components/MapCanvas.tsx
@@ -1,0 +1,291 @@
+import { useRef, useEffect, useMemo, useCallback } from 'react';
+import {
+  MAP_CONFIG,
+  generateLayoutWithConnectors,
+  buildLocationGraphFromScenario,
+  normalizeLocationName,
+  type Connector
+} from '../utils/mapLayout';
+import type { Scenario } from '../types/game';
+
+interface MapCanvasProps {
+  scenario: Scenario;
+  currentLocation: string;
+  visitedLocations: string[];
+  revealedLocations?: string[];
+}
+
+type RoomVisibility = 'current' | 'visited' | 'adjacent' | 'unknown';
+
+const PALETTE = {
+  unknown: { bg: '#1a1a1a', border: '#303030', text: '#6e6e6e' },
+  adjacent: { bg: '#141414', border: '#e6e6e6', text: '#f2f2f2' },
+  visited: { bg: '#1a5c32', border: '#2d9651', text: '#a8f0be' },
+  current: { bg: '#1a5c32', border: '#6bff9a', text: '#eafff1' }
+};
+
+const CONNECTOR_COLOR = '#f2f2f2';
+const BACKGROUND_COLOR = '#08080c';
+const GRID_COLOR = '#1a1a24';
+
+export function MapCanvas({
+  scenario,
+  currentLocation,
+  visitedLocations,
+  revealedLocations = []
+}: MapCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Build layout data from scenario
+  const layoutData = useMemo(() => {
+    const { locations, displayNames, meta } = buildLocationGraphFromScenario(scenario);
+    if (Object.keys(locations).length === 0) return null;
+
+    const result = generateLayoutWithConnectors(locations, { totalTries: 50 });
+    return { result, displayNames, meta, locations };
+  }, [scenario]);
+
+  // Get current location connections for adjacency detection
+  const currentConnections = useMemo(() => {
+    if (!layoutData) return new Set<string>();
+    const normalizedCurrent = normalizeLocationName(currentLocation);
+    const connections = layoutData.locations[normalizedCurrent]?.connections || [];
+    return new Set(connections.map(normalizeLocationName));
+  }, [layoutData, currentLocation]);
+
+  // Normalize sets for quick lookup
+  const normalizedVisited = useMemo(
+    () => new Set(visitedLocations.map(normalizeLocationName)),
+    [visitedLocations]
+  );
+  const normalizedRevealed = useMemo(
+    () => new Set(revealedLocations.map(normalizeLocationName)),
+    [revealedLocations]
+  );
+  const normalizedCurrent = useMemo(
+    () => normalizeLocationName(currentLocation),
+    [currentLocation]
+  );
+
+  // Helper to determine room visibility
+  const getVisibility = useCallback((name: string): RoomVisibility => {
+    if (name === normalizedCurrent) return 'current';
+    if (normalizedVisited.has(name)) return 'visited';
+    if (currentConnections.has(name) || normalizedRevealed.has(name)) return 'adjacent';
+    return 'unknown';
+  }, [normalizedCurrent, normalizedVisited, normalizedRevealed, currentConnections]);
+
+  // Draw function
+  const draw = useCallback((ctx: CanvasRenderingContext2D, width: number, height: number) => {
+    if (!layoutData) return;
+
+    const { result, displayNames, meta } = layoutData;
+    const { layout, connectors } = result;
+    const { CELL_SIZE, ROOM_PADDING, CONNECTOR_WIDTH } = MAP_CONFIG;
+
+    // Calculate canvas dimensions from grid
+    const canvasWidth = layout.gridSize.cols * CELL_SIZE;
+    const canvasHeight = layout.gridSize.rows * CELL_SIZE;
+
+    // Scale to fit container while maintaining aspect ratio
+    const scaleX = width / canvasWidth;
+    const scaleY = height / canvasHeight;
+    const scale = Math.min(scaleX, scaleY, 1); // Don't scale up
+
+    // Clear canvas
+    ctx.fillStyle = BACKGROUND_COLOR;
+    ctx.fillRect(0, 0, width, height);
+
+    // Center the map
+    const offsetX = (width - canvasWidth * scale) / 2;
+    const offsetY = (height - canvasHeight * scale) / 2;
+
+    ctx.save();
+    ctx.translate(offsetX, offsetY);
+    ctx.scale(scale, scale);
+
+    // Draw grid (subtle debug lines)
+    ctx.strokeStyle = GRID_COLOR;
+    ctx.lineWidth = 1;
+    for (let x = 0; x <= layout.gridSize.cols; x++) {
+      ctx.beginPath();
+      ctx.moveTo(x * CELL_SIZE, 0);
+      ctx.lineTo(x * CELL_SIZE, layout.gridSize.rows * CELL_SIZE);
+      ctx.stroke();
+    }
+    for (let y = 0; y <= layout.gridSize.rows; y++) {
+      ctx.beginPath();
+      ctx.moveTo(0, y * CELL_SIZE);
+      ctx.lineTo(layout.gridSize.cols * CELL_SIZE, y * CELL_SIZE);
+      ctx.stroke();
+    }
+
+    // Draw connectors
+    const drawConnector = (conn: Connector) => {
+      const { path, fromPoint, toPoint } = conn;
+
+      ctx.strokeStyle = CONNECTOR_COLOR;
+      ctx.lineWidth = Math.max(4, CONNECTOR_WIDTH + 2);
+      ctx.lineCap = 'square';
+
+      ctx.beginPath();
+      ctx.moveTo(path[0].x, path[0].y);
+      for (let i = 1; i < path.length; i++) {
+        ctx.lineTo(path[i].x, path[i].y);
+      }
+      ctx.stroke();
+
+      // Connection points
+      ctx.fillStyle = CONNECTOR_COLOR;
+      const dotSize = CONNECTOR_WIDTH + 2;
+      ctx.fillRect(fromPoint.x - dotSize / 2, fromPoint.y - dotSize / 2, dotSize, dotSize);
+      ctx.fillRect(toPoint.x - dotSize / 2, toPoint.y - dotSize / 2, dotSize, dotSize);
+    };
+
+    for (const conn of connectors) {
+      drawConnector(conn);
+    }
+
+    // Draw scanlines helper
+    const drawScanlines = (x: number, y: number, w: number, h: number) => {
+      ctx.save();
+      ctx.globalAlpha = 0.15;
+      ctx.fillStyle = '#000000';
+      for (let i = 0; i < h; i += 4) {
+        ctx.fillRect(x, y + i, w, 1);
+      }
+      ctx.restore();
+    };
+
+    // Draw rooms
+    const drawRoom = (
+      name: string,
+      gridX: number,
+      gridY: number,
+      height: number,
+      visibility: RoomVisibility,
+      dangerLevel: number
+    ) => {
+      const x = gridX * CELL_SIZE + ROOM_PADDING;
+      const y = gridY * CELL_SIZE + ROOM_PADDING;
+      const w = CELL_SIZE - ROOM_PADDING * 2;
+      const h = CELL_SIZE * height - ROOM_PADDING * 2;
+
+      const colors = PALETTE[visibility];
+
+      // Background
+      ctx.fillStyle = colors.bg;
+      ctx.fillRect(x, y, w, h);
+
+      // Border
+      ctx.strokeStyle = colors.border;
+      ctx.lineWidth = visibility === 'current' ? 3 : 2;
+      ctx.strokeRect(x, y, w, h);
+
+      // Scanlines effect
+      drawScanlines(x, y, w, h);
+
+      // Text
+      ctx.fillStyle = colors.text;
+      ctx.font = '11px "JetBrains Mono", Consolas, Monaco, monospace';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+
+      const label = visibility === 'unknown' ? '[ ? ? ? ]' : name.toUpperCase();
+      const words = label.split(' ');
+      const lines: string[] = [];
+      let currentLine = '';
+      const maxWidth = w - 10;
+
+      for (const word of words) {
+        const testLine = currentLine ? currentLine + ' ' + word : word;
+        const metrics = ctx.measureText(testLine);
+        if (metrics.width > maxWidth && currentLine) {
+          lines.push(currentLine);
+          currentLine = word;
+        } else {
+          currentLine = testLine;
+        }
+      }
+      if (currentLine) lines.push(currentLine);
+
+      const lineHeight = 14;
+      const startY = y + h / 2 - (lines.length - 1) * lineHeight / 2;
+
+      for (let i = 0; i < lines.length; i++) {
+        ctx.fillText(lines[i], x + w / 2, startY + i * lineHeight);
+      }
+
+      // Danger indicator
+      if ((visibility === 'current' || visibility === 'visited') && dangerLevel > 0) {
+        const size = 8;
+        const pad = 4;
+        ctx.fillStyle = '#8f2d2d';
+        ctx.fillRect(x + w - size - pad, y + pad, size, size);
+      }
+    };
+
+    // Render each room
+    for (const [name, pos] of Object.entries(layout.positions)) {
+      const height = layout.roomSizes[name]?.height || 1;
+      const visibility = getVisibility(name);
+      const displayName = displayNames?.[name] || name;
+      const dangerLevel = meta?.[name]?.dangers?.length || 0;
+
+      drawRoom(displayName, pos.x, pos.y, height, visibility, dangerLevel);
+    }
+
+    ctx.restore();
+  }, [layoutData, getVisibility]);
+
+  // Canvas resize and redraw effect
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
+
+    const resizeAndDraw = () => {
+      const rect = container.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+
+      // Set canvas size with device pixel ratio for sharp rendering
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      canvas.style.width = `${rect.width}px`;
+      canvas.style.height = `${rect.height}px`;
+
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+
+      ctx.scale(dpr, dpr);
+      draw(ctx, rect.width, rect.height);
+    };
+
+    resizeAndDraw();
+
+    // Observe container resize
+    const resizeObserver = new ResizeObserver(resizeAndDraw);
+    resizeObserver.observe(container);
+
+    return () => resizeObserver.disconnect();
+  }, [draw]);
+
+  if (!layoutData) {
+    return (
+      <div className="flex items-center justify-center h-full text-[var(--color-text-dim)]">
+        Aucune carte disponible
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="w-full h-full">
+      <canvas
+        ref={canvasRef}
+        className="block w-full h-full"
+        style={{ imageRendering: 'pixelated' }}
+      />
+    </div>
+  );
+}

--- a/pwa/src/components/MapModal.tsx
+++ b/pwa/src/components/MapModal.tsx
@@ -1,4 +1,5 @@
 import { useGameStore } from '../stores/gameStore';
+import { MapCanvas } from './MapCanvas';
 
 interface MapModalProps {
   isOpen: boolean;
@@ -11,98 +12,109 @@ export function MapModal({ isOpen, onClose }: MapModalProps) {
   if (!isOpen || !gameState) return null;
 
   const { scenario, currentLocation, visitedLocations } = gameState;
-  const locations = Object.values(scenario.locations);
+
+  // Get revealed locations (adjacent to visited locations)
+  const revealedLocations = Object.values(scenario.locations)
+    .filter(loc => loc.discovered)
+    .map(loc => loc.name);
 
   return (
     <div
-      className="fixed inset-0 bg-black/80 z-50 flex items-end justify-center"
+      className="fixed inset-0 bg-black/90 z-50 flex flex-col animate-fade-in"
       onClick={onClose}
     >
+      {/* Header */}
       <div
-        className="bg-[var(--color-steel)] w-full max-w-md max-h-[80vh] rounded-t-2xl overflow-hidden animate-fade-in"
+        className="flex items-center justify-between p-4 border-b border-[var(--color-panel)] bg-[var(--color-void)]"
         onClick={(e) => e.stopPropagation()}
       >
-        {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b border-[var(--color-panel)]">
-          <h2 className="text-lg font-bold">🗺️ Carte</h2>
-          <button
-            className="w-8 h-8 flex items-center justify-center rounded-full bg-[var(--color-panel)]"
-            onClick={onClose}
+        <h2 className="text-lg font-bold text-[var(--color-text)]">Carte</h2>
+        <button
+          className="w-10 h-10 flex items-center justify-center rounded-full bg-[var(--color-panel)] text-[var(--color-text)] hover:bg-[var(--color-steel)] transition-colors"
+          onClick={onClose}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
           >
-            ✕
-          </button>
-        </div>
+            <line x1="18" y1="6" x2="6" y2="18"></line>
+            <line x1="6" y1="6" x2="18" y2="18"></line>
+          </svg>
+        </button>
+      </div>
 
-        {/* Content */}
-        <div className="p-4 overflow-y-auto max-h-[60vh]">
-          <div className="space-y-2">
-            {locations.map((location) => {
-              const isCurrentLocation = location.name === currentLocation;
-              const isVisited = visitedLocations.includes(location.name);
-              const isDiscovered = location.discovered || isVisited;
+      {/* Map Canvas - Full height */}
+      <div
+        className="flex-1 min-h-0 overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <MapCanvas
+          scenario={scenario}
+          currentLocation={currentLocation}
+          visitedLocations={visitedLocations}
+          revealedLocations={revealedLocations}
+        />
+      </div>
 
-              return (
-                <div
-                  key={location.name}
-                  className={`
-                    p-3 rounded-lg border transition-all
-                    ${isCurrentLocation
-                      ? 'bg-[var(--color-accent)]/20 border-[var(--color-accent)]'
-                      : isDiscovered
-                        ? 'bg-[var(--color-panel)] border-[var(--color-panel)]'
-                        : 'bg-[var(--color-void)] border-[var(--color-void)] opacity-50'}
-                  `}
-                >
-                  <div className="flex items-center gap-2">
-                    {isCurrentLocation && <span>📍</span>}
-                    {!isCurrentLocation && isVisited && <span className="text-[var(--color-success)]">✓</span>}
-                    {!isDiscovered && <span>❓</span>}
-                    <span className={`font-medium ${!isDiscovered ? 'text-[var(--color-text-dim)]' : ''}`}>
-                      {isDiscovered ? location.name : '???'}
-                    </span>
-                  </div>
-
-                  {isDiscovered && (
-                    <>
-                      <p className="text-sm text-[var(--color-text-dim)] mt-1">
-                        {location.description}
-                      </p>
-
-                      {/* Connections */}
-                      {location.connections.length > 0 && (
-                        <div className="mt-2 text-xs text-[var(--color-text-dim)]">
-                          <span>Connecté à : </span>
-                          {location.connections.map((conn, i) => (
-                            <span key={conn}>
-                              <span className={visitedLocations.includes(conn) ? 'text-[var(--color-success)]' : ''}>
-                                {conn}
-                              </span>
-                              {i < location.connections.length - 1 && ', '}
-                            </span>
-                          ))}
-                        </div>
-                      )}
-
-                      {/* Dangers indicator */}
-                      {location.dangers.length > 0 && (
-                        <div className="mt-1 text-xs text-[var(--color-accent)]">
-                          ⚠️ Zone dangereuse
-                        </div>
-                      )}
-                    </>
-                  )}
-                </div>
-              );
-            })}
+      {/* Legend */}
+      <div
+        className="p-4 border-t border-[var(--color-panel)] bg-[var(--color-void)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex flex-wrap items-center justify-center gap-4 text-xs text-[var(--color-text-dim)]">
+          <div className="flex items-center gap-2">
+            <span
+              className="w-4 h-4 rounded border-2"
+              style={{
+                backgroundColor: '#1a5c32',
+                borderColor: '#6bff9a'
+              }}
+            />
+            <span>Position actuelle</span>
           </div>
-
-          {/* Legend */}
-          <div className="mt-4 pt-4 border-t border-[var(--color-panel)] text-xs text-[var(--color-text-dim)]">
-            <div className="flex gap-4">
-              <span>📍 Position actuelle</span>
-              <span className="text-[var(--color-success)]">✓ Visité</span>
-              <span>❓ Inconnu</span>
-            </div>
+          <div className="flex items-center gap-2">
+            <span
+              className="w-4 h-4 rounded border-2"
+              style={{
+                backgroundColor: '#1a5c32',
+                borderColor: '#2d9651'
+              }}
+            />
+            <span>Lieu explore</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span
+              className="w-4 h-4 rounded border-2"
+              style={{
+                backgroundColor: '#141414',
+                borderColor: '#e6e6e6'
+              }}
+            />
+            <span>Lieu adjacent</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span
+              className="w-4 h-4 rounded border-2"
+              style={{
+                backgroundColor: '#1a1a1a',
+                borderColor: '#303030'
+              }}
+            />
+            <span>Inconnu</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span
+              className="w-3 h-3 rounded-sm"
+              style={{ backgroundColor: '#8f2d2d' }}
+            />
+            <span>Zone dangereuse</span>
           </div>
         </div>
       </div>

--- a/pwa/src/utils/mapLayout.ts
+++ b/pwa/src/utils/mapLayout.ts
@@ -1,0 +1,968 @@
+// ============================================================================
+// MAP LAYOUT ALGORITHM - Spatial room placement and connector routing
+// ============================================================================
+
+// Configuration
+export const MAP_CONFIG = {
+  CELL_SIZE: 100,      // Size of a grid cell
+  ROOM_PADDING: 10,    // Space between cell edge and room
+  CONNECTOR_WIDTH: 6,  // Thickness of connectors
+};
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export interface LocationGraph {
+  [name: string]: {
+    connections: string[];
+  };
+}
+
+export interface Position {
+  x: number;
+  y: number;
+}
+
+export interface RoomSize {
+  width: number;
+  height: number;
+}
+
+export interface GridSize {
+  cols: number;
+  rows: number;
+}
+
+export interface RoomPort {
+  x: number;
+  y: number;
+  side: 'left' | 'right' | 'top' | 'bottom';
+  portKey: string;
+  targetGrid: Position;
+}
+
+export interface Connector {
+  from: string;
+  to: string;
+  path: Position[];
+  fromPoint: RoomPort;
+  toPoint: RoomPort;
+}
+
+export interface ConnectorRoom {
+  cell: Position;
+  type: 'I' | 'L';
+  orientation: string;
+  entry: string;
+  exit: string;
+}
+
+export interface Layout {
+  positions: Record<string, Position>;
+  roomSizes: Record<string, RoomSize>;
+  hubName: string;
+  gridSize: GridSize;
+}
+
+export interface LayoutResult {
+  layout: Layout;
+  connectors: Connector[];
+  connectorRooms: ConnectorRoom[];
+  allConnected: boolean;
+  spacing: number;
+  missingConnections: Array<{ from: string; to: string }>;
+}
+
+// ============================================================================
+// LAYOUT ALGORITHM
+// ============================================================================
+
+export function generateLayout(
+  locations: LocationGraph,
+  options: { spacing?: number } = {}
+): Layout {
+  const spacing = Math.max(0, Math.floor(options.spacing || 0));
+  const scale = spacing + 1;
+  const names = Object.keys(locations);
+
+  // Calculate room sizes (height based on connection count)
+  const roomSizes: Record<string, RoomSize> = {};
+  for (const [name, loc] of Object.entries(locations)) {
+    const connCount = loc.connections?.length || 0;
+    let height = 1;
+    if (connCount >= 5) height = 2;
+    if (connCount >= 7) height = 3;
+    if (connCount >= 9) height = 4;
+    roomSizes[name] = { width: 1, height };
+  }
+
+  // Find the hub (room with most connections)
+  let hubName = names[0];
+  let maxConn = 0;
+  for (const [name, loc] of Object.entries(locations)) {
+    if (loc.connections.length > maxConn) {
+      maxConn = loc.connections.length;
+      hubName = name;
+    }
+  }
+
+  const isOccupiedFactory = (occupied: Set<string>) => (x: number, y: number, h: number): boolean => {
+    for (let dy = 0; dy < h; dy++) {
+      if (occupied.has(`${x},${y + dy}`)) return true;
+    }
+    return false;
+  };
+
+  const occupyFactory = (occupied: Set<string>) => (x: number, y: number, h: number): void => {
+    for (let dy = 0; dy < h; dy++) {
+      occupied.add(`${x},${y + dy}`);
+    }
+  };
+
+  const estimateConnectorLength = (
+    posA: Position,
+    sizeA: RoomSize,
+    posB: Position,
+    sizeB: RoomSize
+  ): number => {
+    const ax = posA.x + 0.5;
+    const ay = posA.y + sizeA.height / 2;
+    const bx = posB.x + 0.5;
+    const by = posB.y + sizeB.height / 2;
+    return Math.abs(ax - bx) + Math.abs(ay - by);
+  };
+
+  const getAdjacentCandidates = (
+    basePos: Position,
+    baseSize: RoomSize,
+    targetHeight: number
+  ): Position[] => {
+    const candidates: Position[] = [];
+    const topY = basePos.y - targetHeight;
+    const bottomY = basePos.y + baseSize.height;
+
+    candidates.push({ x: basePos.x - 1, y: basePos.y });
+    candidates.push({ x: basePos.x + 1, y: basePos.y });
+    candidates.push({ x: basePos.x, y: topY });
+    candidates.push({ x: basePos.x, y: bottomY });
+
+    for (let dy = 0; dy < baseSize.height; dy++) {
+      candidates.push({ x: basePos.x - 1, y: basePos.y + dy - (targetHeight - 1) });
+      candidates.push({ x: basePos.x + 1, y: basePos.y + dy - (targetHeight - 1) });
+    }
+
+    return candidates;
+  };
+
+  const shuffle = <T>(array: T[]): T[] => {
+    const result = [...array];
+    for (let i = result.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [result[i], result[j]] = [result[j], result[i]];
+    }
+    return result;
+  };
+
+  const computeLayoutCost = (positions: Record<string, Position>): number => {
+    let cost = 0;
+    const seen = new Set<string>();
+    for (const [from, loc] of Object.entries(locations)) {
+      for (const to of loc.connections) {
+        const key = [from, to].sort().join('<->');
+        if (seen.has(key)) continue;
+        seen.add(key);
+        if (!positions[from] || !positions[to]) continue;
+
+        const posA = positions[from];
+        const sizeA = roomSizes[from];
+        const posB = positions[to];
+        const sizeB = roomSizes[to];
+
+        const ax1 = posA.x;
+        const ay1 = posA.y;
+        const ay2 = posA.y + sizeA.height - 1;
+        const bx1 = posB.x;
+        const by1 = posB.y;
+        const by2 = posB.y + sizeB.height - 1;
+
+        const dx = ax1 < bx1 ? bx1 - ax1 : bx1 < ax1 ? ax1 - bx1 : 0;
+        const dy = ay2 < by1 ? by1 - ay2 : by2 < ay1 ? ay1 - by2 : 0;
+        cost += dx + dy;
+      }
+    }
+    return cost;
+  };
+
+  const buildLayoutAttempt = (): Record<string, Position> | null => {
+    const positions: Record<string, Position> = {};
+    const occupied = new Set<string>();
+    const isOccupied = isOccupiedFactory(occupied);
+    const occupy = occupyFactory(occupied);
+
+    const placed = new Set<string>();
+    positions[hubName] = { x: 3, y: 3 };
+    occupy(3, 3, roomSizes[hubName].height);
+    placed.add(hubName);
+
+    const remaining = new Set(names.filter(n => n !== hubName));
+    let searchRadius = 1;
+
+    while (remaining.size > 0) {
+      const candidateNames = Array.from(remaining).map(name => {
+        const connectedPlaced = locations[name].connections.filter(c => placed.has(c)).length;
+        const degree = locations[name].connections.length || 0;
+        return { name, score: connectedPlaced * 10 + degree + Math.random() };
+      });
+      candidateNames.sort((a, b) => b.score - a.score);
+      const name = candidateNames[0].name;
+
+      const size = roomSizes[name];
+      let bestPos: Position | null = null;
+      let bestCost = Infinity;
+
+      const connectedPlaced = locations[name].connections.filter(c => placed.has(c));
+      const anchors = connectedPlaced.length > 0 ? connectedPlaced : Array.from(placed);
+
+      const candidateSet = new Map<string, Position>();
+      for (const anchor of anchors) {
+        const anchorPos = positions[anchor];
+        const anchorSize = roomSizes[anchor];
+        for (const cand of getAdjacentCandidates(anchorPos, anchorSize, size.height)) {
+          const key = `${cand.x},${cand.y}`;
+          if (!candidateSet.has(key)) candidateSet.set(key, cand);
+        }
+      }
+
+      for (let r = 1; r <= searchRadius; r++) {
+        for (const anchor of anchors) {
+          const anchorPos = positions[anchor];
+          for (let dx = -r; dx <= r; dx++) {
+            for (let dy = -r; dy <= r; dy++) {
+              const cand = { x: anchorPos.x + dx, y: anchorPos.y + dy };
+              const key = `${cand.x},${cand.y}`;
+              if (!candidateSet.has(key)) candidateSet.set(key, cand);
+            }
+          }
+        }
+      }
+
+      const candidateArray = shuffle(Array.from(candidateSet.values()));
+      for (const cand of candidateArray) {
+        if (cand.x < 0 || cand.y < 0) continue;
+        if (isOccupied(cand.x, cand.y, size.height)) continue;
+
+        let cost = 0;
+        for (const conn of connectedPlaced) {
+          cost += estimateConnectorLength(cand, size, positions[conn], roomSizes[conn]);
+        }
+
+        if (connectedPlaced.length === 0) {
+          for (const other of placed) {
+            cost += estimateConnectorLength(cand, size, positions[other], roomSizes[other]) * 0.25;
+          }
+        }
+
+        cost += Math.abs(cand.x - 3) * 0.05 + Math.abs(cand.y - 3) * 0.05;
+        cost += Math.random() * 0.05;
+
+        if (cost < bestCost) {
+          bestCost = cost;
+          bestPos = cand;
+        }
+      }
+
+      if (!bestPos) {
+        searchRadius += 1;
+        if (searchRadius > 8) return null;
+        continue;
+      }
+
+      positions[name] = bestPos;
+      occupy(bestPos.x, bestPos.y, size.height);
+      placed.add(name);
+      remaining.delete(name);
+    }
+
+    return positions;
+  };
+
+  const ATTEMPTS = 100;
+  let bestPositions: Record<string, Position> | null = null;
+  let bestCost = Infinity;
+
+  for (let i = 0; i < ATTEMPTS; i++) {
+    const attempt = buildLayoutAttempt();
+    if (!attempt) continue;
+    const cost = computeLayoutCost(attempt);
+    if (cost < bestCost) {
+      bestCost = cost;
+      bestPositions = attempt;
+    }
+  }
+
+  const positions = bestPositions || buildLayoutAttempt() || {};
+
+  // Center the hub in the grid by adding symmetric padding
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const [n, pos] of Object.entries(positions)) {
+    minX = Math.min(minX, pos.x);
+    minY = Math.min(minY, pos.y);
+    maxX = Math.max(maxX, pos.x);
+    maxY = Math.max(maxY, pos.y + (roomSizes[n].height - 1));
+  }
+
+  if (positions[hubName]) {
+    const hubPos = positions[hubName];
+    const leftDist = hubPos.x - minX;
+    const rightDist = maxX - hubPos.x;
+    const topDist = hubPos.y - minY;
+    const bottomDist = maxY - hubPos.y;
+
+    const targetHubX = Math.max(leftDist, rightDist);
+    const targetHubY = Math.max(topDist, bottomDist);
+    const offsetX = targetHubX - hubPos.x;
+    const offsetY = targetHubY - hubPos.y;
+
+    for (const pos of Object.values(positions)) {
+      pos.x += offsetX;
+      pos.y += offsetY;
+    }
+  }
+
+  // Apply spacing to leave corridors between rooms
+  if (scale !== 1) {
+    for (const pos of Object.values(positions)) {
+      pos.x *= scale;
+      pos.y *= scale;
+    }
+  }
+
+  // Calculate grid size without compacting (to leave margin for connectors)
+  maxX = 0;
+  maxY = 0;
+  for (const [n, pos] of Object.entries(positions)) {
+    maxX = Math.max(maxX, pos.x);
+    maxY = Math.max(maxY, pos.y + (roomSizes[n].height - 1));
+  }
+
+  const GRID_PADDING = 2;
+  for (const pos of Object.values(positions)) {
+    pos.x += GRID_PADDING;
+    pos.y += GRID_PADDING;
+  }
+
+  return {
+    positions,
+    roomSizes,
+    hubName,
+    gridSize: { cols: maxX + 1 + GRID_PADDING * 2, rows: maxY + 1 + GRID_PADDING * 2 }
+  };
+}
+
+// ============================================================================
+// CONNECTOR COMPUTATION
+// ============================================================================
+
+function makeRoomPort(
+  gridX: number,
+  gridY: number,
+  height: number,
+  side: 'left' | 'right' | 'top' | 'bottom',
+  row: number = 0
+): RoomPort {
+  const { CELL_SIZE, ROOM_PADDING } = MAP_CONFIG;
+
+  if (side === 'left' || side === 'right') {
+    const safeRow = Math.max(0, Math.min(height - 1, row));
+    const y = (gridY + safeRow) * CELL_SIZE + CELL_SIZE / 2;
+    const x = side === 'left'
+      ? gridX * CELL_SIZE + ROOM_PADDING
+      : gridX * CELL_SIZE + CELL_SIZE - ROOM_PADDING;
+    return {
+      x,
+      y,
+      side,
+      portKey: `${side}:${safeRow}`,
+      targetGrid: { x: gridX + (side === 'left' ? -1 : 1), y: gridY + safeRow }
+    };
+  }
+
+  const x = gridX * CELL_SIZE + CELL_SIZE / 2;
+  const y = side === 'top'
+    ? gridY * CELL_SIZE + ROOM_PADDING
+    : gridY * CELL_SIZE + CELL_SIZE * height - ROOM_PADDING;
+  return {
+    x,
+    y,
+    side,
+    portKey: `${side}:0`,
+    targetGrid: { x: gridX, y: gridY + (side === 'top' ? -1 : height) }
+  };
+}
+
+function getConnectionPoints(gridX: number, gridY: number, height: number): RoomPort[] {
+  const points: RoomPort[] = [];
+
+  points.push(makeRoomPort(gridX, gridY, height, 'top', 0));
+  points.push(makeRoomPort(gridX, gridY, height, 'bottom', 0));
+
+  for (let row = 0; row < height; row++) {
+    points.push(makeRoomPort(gridX, gridY, height, 'left', row));
+    points.push(makeRoomPort(gridX, gridY, height, 'right', row));
+  }
+
+  return points;
+}
+
+export function computeConnectors(
+  locations: LocationGraph,
+  layout: Layout
+): {
+  connectors: Connector[];
+  connectorRooms: ConnectorRoom[];
+  allConnected: boolean;
+  missingConnections: Array<{ from: string; to: string }>;
+} {
+  const connectors: Connector[] = [];
+  const connectorRooms: ConnectorRoom[] = [];
+  const processed = new Set<string>();
+  const roomPoints: Record<string, RoomPort[]> = {};
+  const usedPorts: Record<string, Set<string>> = {};
+  const roomBlocked = new Set<string>();
+  const connectorBlockedCells = new Set<string>();
+  const connectorBlockedEdges = new Set<string>();
+  const missingConnections: Array<{ from: string; to: string }> = [];
+
+  const cellKey = (x: number, y: number) => `${x},${y}`;
+  const edgeKey = (a: Position, b: Position) => {
+    const k1 = cellKey(a.x, a.y);
+    const k2 = cellKey(b.x, b.y);
+    return k1 < k2 ? `${k1}|${k2}` : `${k2}|${k1}`;
+  };
+
+  const sideOpposite = (side: string): string => {
+    if (side === 'left') return 'right';
+    if (side === 'right') return 'left';
+    if (side === 'top') return 'bottom';
+    return 'top';
+  };
+
+  const sideToDir = (side: string): string => {
+    if (side === 'right') return 'right';
+    if (side === 'left') return 'left';
+    if (side === 'bottom') return 'down';
+    return 'up';
+  };
+
+  const dirBetween = (a: Position, b: Position): string => {
+    if (b.x > a.x) return 'right';
+    if (b.x < a.x) return 'left';
+    if (b.y > a.y) return 'down';
+    return 'up';
+  };
+
+  const edgeCenter = (cell: Position, side: string): Position => {
+    const { CELL_SIZE } = MAP_CONFIG;
+    const x = cell.x * CELL_SIZE;
+    const y = cell.y * CELL_SIZE;
+    if (side === 'left') return { x: x, y: y + CELL_SIZE / 2 };
+    if (side === 'right') return { x: x + CELL_SIZE, y: y + CELL_SIZE / 2 };
+    if (side === 'top') return { x: x + CELL_SIZE / 2, y: y };
+    return { x: x + CELL_SIZE / 2, y: y + CELL_SIZE };
+  };
+
+  for (const [name, pos] of Object.entries(layout.positions)) {
+    const h = layout.roomSizes[name]?.height || 1;
+    for (let dy = 0; dy < h; dy++) {
+      roomBlocked.add(cellKey(pos.x, pos.y + dy));
+    }
+  }
+
+  const findGridPath = (start: Position, goal: Position): Position[] | null => {
+    const cols = layout.gridSize.cols;
+    const rows = layout.gridSize.rows;
+    if (!start || !goal) return null;
+    if (start.x < 0 || start.y < 0 || goal.x < 0 || goal.y < 0) return null;
+    if (start.x >= cols || start.y >= rows || goal.x >= cols || goal.y >= rows) return null;
+
+    const deltas = [
+      { x: 1, y: 0 },
+      { x: -1, y: 0 },
+      { x: 0, y: 1 },
+      { x: 0, y: -1 }
+    ];
+
+    interface PathNode {
+      x: number;
+      y: number;
+      dir: number;
+      steps: number;
+      turns: number;
+    }
+
+    const startNode: PathNode = { x: start.x, y: start.y, dir: -1, steps: 0, turns: 0 };
+    const open: PathNode[] = [startNode];
+    const bestScore = new Map<string, number>();
+    const cameFrom = new Map<string, string>();
+
+    const scoreOf = (node: PathNode) => node.steps * 1000 + node.turns * 10;
+    bestScore.set(`${start.x},${start.y},-1`, 0);
+
+    let goalKey: string | null = null;
+    let goalNode: PathNode | null = null;
+
+    while (open.length > 0) {
+      let bestIndex = 0;
+      let bestValue = scoreOf(open[0]);
+      for (let i = 1; i < open.length; i++) {
+        const val = scoreOf(open[i]);
+        if (val < bestValue) {
+          bestValue = val;
+          bestIndex = i;
+        }
+      }
+
+      const current = open.splice(bestIndex, 1)[0];
+      if (current.x === goal.x && current.y === goal.y) {
+        goalNode = current;
+        goalKey = `${current.x},${current.y},${current.dir}`;
+        break;
+      }
+
+      for (let d = 0; d < deltas.length; d++) {
+        if (current.dir !== -1 && (d + 2) % 4 === current.dir) continue;
+
+        const next = { x: current.x + deltas[d].x, y: current.y + deltas[d].y };
+        if (next.x < 0 || next.y < 0 || next.x >= cols || next.y >= rows) continue;
+
+        const nextKey = cellKey(next.x, next.y);
+        if (roomBlocked.has(nextKey) && !(next.x === goal.x && next.y === goal.y)) continue;
+        if (connectorBlockedCells.has(nextKey) && !(next.x === goal.x && next.y === goal.y)) continue;
+
+        const eKey = edgeKey(current, next);
+        if (connectorBlockedEdges.has(eKey)) continue;
+
+        const turns = current.turns + (current.dir === -1 || current.dir === d ? 0 : 1);
+        const steps = current.steps + 1;
+        const nodeKey = `${next.x},${next.y},${d}`;
+        const nodeScore = steps * 1000 + turns * 10;
+
+        if (!bestScore.has(nodeKey) || nodeScore < bestScore.get(nodeKey)!) {
+          bestScore.set(nodeKey, nodeScore);
+          cameFrom.set(nodeKey, `${current.x},${current.y},${current.dir}`);
+          open.push({ x: next.x, y: next.y, dir: d, steps, turns });
+        }
+      }
+    }
+
+    if (!goalNode) return null;
+
+    const path: Position[] = [{ x: goalNode.x, y: goalNode.y }];
+    let cursorKey: string | null = goalKey;
+    while (cursorKey) {
+      const prevKey = cameFrom.get(cursorKey);
+      if (!prevKey) break;
+      const [px, py] = prevKey.split(',').map(v => parseInt(v, 10));
+      path.push({ x: px, y: py });
+      cursorKey = prevKey;
+    }
+    path.reverse();
+    return path;
+  };
+
+  const addConnectorRooms = (gridPath: Position[], fromPoint: RoomPort, toPoint: RoomPort): void => {
+    if (!gridPath || gridPath.length === 0) return;
+
+    const entrySide = sideOpposite(fromPoint.side);
+    const exitSide = sideOpposite(toPoint.side);
+
+    for (let i = 0; i < gridPath.length; i++) {
+      const cell = gridPath[i];
+      const prev = i === 0 ? null : gridPath[i - 1];
+      const next = i === gridPath.length - 1 ? null : gridPath[i + 1];
+
+      const enterDir = prev
+        ? dirBetween(prev, cell)
+        : sideToDir(entrySide);
+      const exitDir = next
+        ? dirBetween(cell, next)
+        : sideToDir(exitSide);
+
+      const straight = enterDir === exitDir;
+      let type: 'I' | 'L' = 'I';
+      let orientation = enterDir === 'left' || enterDir === 'right' ? 'horizontal' : 'vertical';
+      if (!straight) {
+        type = 'L';
+        const turn = `${enterDir}->${exitDir}`;
+        const rightTurns = new Set(['up->right', 'right->down', 'down->left', 'left->up']);
+        orientation = rightTurns.has(turn) ? 'right' : 'left';
+      }
+
+      connectorRooms.push({
+        cell: { x: cell.x, y: cell.y },
+        type,
+        orientation,
+        entry: enterDir,
+        exit: exitDir
+      });
+    }
+  };
+
+  const buildConnectorPath = (gridPath: Position[] | null, fromPoint: RoomPort, toPoint: RoomPort): Position[] => {
+    const path: Position[] = [];
+    const pushPoint = (pt: Position) => {
+      const last = path[path.length - 1];
+      if (!last || last.x !== pt.x || last.y !== pt.y) path.push(pt);
+    };
+
+    pushPoint({ x: fromPoint.x, y: fromPoint.y });
+
+    if (gridPath && gridPath.length > 0) {
+      const entrySide = sideOpposite(fromPoint.side);
+      const exitSide = sideOpposite(toPoint.side);
+
+      const firstCell = gridPath[0];
+      pushPoint(edgeCenter(firstCell, entrySide));
+
+      for (let i = 0; i < gridPath.length - 1; i++) {
+        const cell = gridPath[i];
+        const next = gridPath[i + 1];
+        const dir = dirBetween(cell, next);
+        const side = dir === 'right' ? 'right' : dir === 'left' ? 'left' : dir === 'down' ? 'bottom' : 'top';
+        pushPoint(edgeCenter(cell, side));
+      }
+
+      const lastCell = gridPath[gridPath.length - 1];
+      pushPoint(edgeCenter(lastCell, exitSide));
+    }
+
+    pushPoint({ x: toPoint.x, y: toPoint.y });
+    return path;
+  };
+
+  const getDirectAdjacency = (from: string, to: string): {
+    left?: string;
+    right?: string;
+    top?: string;
+    bottom?: string;
+    rows?: number[];
+  } | null => {
+    const fromPos = layout.positions[from];
+    const toPos = layout.positions[to];
+    if (!fromPos || !toPos) return null;
+
+    const fromH = layout.roomSizes[from]?.height || 1;
+    const toH = layout.roomSizes[to]?.height || 1;
+
+    const overlapStart = Math.max(fromPos.y, toPos.y);
+    const overlapEnd = Math.min(fromPos.y + fromH - 1, toPos.y + toH - 1);
+    const overlapRows: number[] = [];
+    for (let r = overlapStart; r <= overlapEnd; r++) overlapRows.push(r);
+
+    if (fromPos.x + 1 === toPos.x && overlapRows.length > 0) {
+      return { left: from, right: to, rows: overlapRows };
+    }
+    if (toPos.x + 1 === fromPos.x && overlapRows.length > 0) {
+      return { left: to, right: from, rows: overlapRows };
+    }
+
+    if (fromPos.y + fromH === toPos.y && fromPos.x === toPos.x) {
+      return { top: from, bottom: to };
+    }
+    if (toPos.y + toH === fromPos.y && fromPos.x === toPos.x) {
+      return { top: to, bottom: from };
+    }
+
+    return null;
+  };
+
+  let expectedConnections = 0;
+  for (const [, loc] of Object.entries(locations)) {
+    for (const to of loc.connections) {
+      const key = [, to].sort().join('<->');
+      if (processed.has(key)) continue;
+      processed.add(key);
+      expectedConnections += 1;
+    }
+  }
+
+  processed.clear();
+
+  for (const [from, loc] of Object.entries(locations)) {
+    for (const to of loc.connections) {
+      const key = [from, to].sort().join('<->');
+      if (processed.has(key)) continue;
+      processed.add(key);
+
+      const fromPos = layout.positions[from];
+      const toPos = layout.positions[to];
+      if (!fromPos || !toPos) continue;
+
+      const fromH = layout.roomSizes[from]?.height || 1;
+      const toH = layout.roomSizes[to]?.height || 1;
+
+      if (!roomPoints[from]) roomPoints[from] = getConnectionPoints(fromPos.x, fromPos.y, fromH);
+      if (!roomPoints[to]) roomPoints[to] = getConnectionPoints(toPos.x, toPos.y, toH);
+      if (!usedPorts[from]) usedPorts[from] = new Set();
+      if (!usedPorts[to]) usedPorts[to] = new Set();
+
+      const adjacency = getDirectAdjacency(from, to);
+      if (adjacency) {
+        if (adjacency.left && adjacency.right) {
+          const leftPos = layout.positions[adjacency.left];
+          const rightPos = layout.positions[adjacency.right];
+          const leftH = layout.roomSizes[adjacency.left]?.height || 1;
+          const rightH = layout.roomSizes[adjacency.right]?.height || 1;
+
+          const rows = adjacency.rows || [];
+          const targetRow = rows.length > 0 ? rows[Math.floor(rows.length / 2)] : leftPos.y;
+          const leftRow = Math.max(0, Math.min(leftH - 1, targetRow - leftPos.y));
+          const rightRow = Math.max(0, Math.min(rightH - 1, targetRow - rightPos.y));
+
+          const leftPort = makeRoomPort(leftPos.x, leftPos.y, leftH, 'right', leftRow);
+          const rightPort = makeRoomPort(rightPos.x, rightPos.y, rightH, 'left', rightRow);
+
+          if (!usedPorts[adjacency.left].has(leftPort.portKey) && !usedPorts[adjacency.right].has(rightPort.portKey)) {
+            usedPorts[adjacency.left].add(leftPort.portKey);
+            usedPorts[adjacency.right].add(rightPort.portKey);
+            connectors.push({
+              from: adjacency.left,
+              to: adjacency.right,
+              path: [leftPort, rightPort],
+              fromPoint: leftPort,
+              toPoint: rightPort
+            });
+            continue;
+          }
+        } else if (adjacency.top && adjacency.bottom) {
+          const topPos = layout.positions[adjacency.top];
+          const bottomPos = layout.positions[adjacency.bottom];
+          const topH = layout.roomSizes[adjacency.top]?.height || 1;
+          const bottomH = layout.roomSizes[adjacency.bottom]?.height || 1;
+          const topPort = makeRoomPort(topPos.x, topPos.y, topH, 'bottom', 0);
+          const bottomPort = makeRoomPort(bottomPos.x, bottomPos.y, bottomH, 'top', 0);
+
+          if (!usedPorts[adjacency.top].has(topPort.portKey) && !usedPorts[adjacency.bottom].has(bottomPort.portKey)) {
+            usedPorts[adjacency.top].add(topPort.portKey);
+            usedPorts[adjacency.bottom].add(bottomPort.portKey);
+            connectors.push({
+              from: adjacency.top,
+              to: adjacency.bottom,
+              path: [topPort, bottomPort],
+              fromPoint: topPort,
+              toPoint: bottomPort
+            });
+            continue;
+          }
+        }
+      }
+
+      const fromPoints = roomPoints[from];
+      const toPoints = roomPoints[to];
+
+      let bestFromIndex = -1;
+      let bestToIndex = -1;
+      let bestPathLen = Infinity;
+      let bestTurns = Infinity;
+      let bestGridPath: Position[] | null = null;
+
+      const countTurns = (path: Position[]): number => {
+        let turns = 0;
+        for (let i = 2; i < path.length; i++) {
+          const dirA = dirBetween(path[i - 2], path[i - 1]);
+          const dirB = dirBetween(path[i - 1], path[i]);
+          if (dirA !== dirB) turns++;
+        }
+        return turns;
+      };
+
+      const tryPair = (i: number, j: number): void => {
+        const fp = fromPoints[i];
+        const tp = toPoints[j];
+        if (!fp?.targetGrid || !tp?.targetGrid) return;
+        if (usedPorts[from].has(fp.portKey)) return;
+        if (usedPorts[to].has(tp.portKey)) return;
+
+        const startKey = cellKey(fp.targetGrid.x, fp.targetGrid.y);
+        const endKey = cellKey(tp.targetGrid.x, tp.targetGrid.y);
+        if (roomBlocked.has(startKey) || roomBlocked.has(endKey)) return;
+        if (connectorBlockedCells.has(startKey) || connectorBlockedCells.has(endKey)) return;
+
+        const gridPath = findGridPath(fp.targetGrid, tp.targetGrid);
+        if (!gridPath) return;
+
+        const len = gridPath.length;
+        const turns = countTurns(gridPath);
+        if (len < bestPathLen || (len === bestPathLen && turns < bestTurns)) {
+          bestPathLen = len;
+          bestTurns = turns;
+          bestFromIndex = i;
+          bestToIndex = j;
+          bestGridPath = gridPath;
+        }
+      };
+
+      for (let i = 0; i < fromPoints.length; i++) {
+        for (let j = 0; j < toPoints.length; j++) {
+          tryPair(i, j);
+        }
+      }
+
+      if (!bestGridPath) {
+        missingConnections.push({ from, to });
+        continue;
+      }
+
+      // Create a const reference for TypeScript narrowing
+      const finalGridPath: Position[] = bestGridPath;
+
+      const bestFrom = fromPoints[bestFromIndex] || fromPoints[0];
+      const bestTo = toPoints[bestToIndex] || toPoints[0];
+
+      usedPorts[from].add(bestFrom.portKey);
+      usedPorts[to].add(bestTo.portKey);
+
+      for (let i = 0; i < finalGridPath.length; i++) {
+        connectorBlockedCells.add(cellKey(finalGridPath[i].x, finalGridPath[i].y));
+        if (i > 0) {
+          connectorBlockedEdges.add(edgeKey(finalGridPath[i - 1], finalGridPath[i]));
+        }
+      }
+
+      addConnectorRooms(finalGridPath, bestFrom, bestTo);
+      const path = buildConnectorPath(finalGridPath, bestFrom, bestTo);
+      connectors.push({ from, to, path, fromPoint: bestFrom, toPoint: bestTo });
+    }
+  }
+
+  const allConnected = missingConnections.length === 0 && connectors.length === expectedConnections;
+  return { connectors, connectorRooms, allConnected, missingConnections };
+}
+
+// ============================================================================
+// COMBINED LAYOUT WITH CONNECTORS
+// ============================================================================
+
+export function generateLayoutWithConnectors(
+  locations: LocationGraph,
+  options: { totalTries?: number; spacingLevels?: number[] } = {}
+): LayoutResult {
+  const totalTries = Math.max(1, options.totalTries || 50);
+  const spacingLevels = options.spacingLevels || [0, 1, 2];
+  let bestResult: LayoutResult | null = null;
+  let bestLength = Infinity;
+
+  const connectorLengthSum = (connectors: Connector[]): number => {
+    let total = 0;
+    for (const conn of connectors) {
+      for (let i = 1; i < conn.path.length; i++) {
+        const a = conn.path[i - 1];
+        const b = conn.path[i];
+        total += Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+      }
+    }
+    return total;
+  };
+
+  for (let i = 0; i < totalTries; i++) {
+    const spacing = spacingLevels[i % spacingLevels.length];
+    const layout = generateLayout(locations, { spacing });
+    const result = computeConnectors(locations, layout);
+    const lengthSum = connectorLengthSum(result.connectors);
+    const candidate: LayoutResult = {
+      layout,
+      connectors: result.connectors,
+      connectorRooms: result.connectorRooms,
+      allConnected: result.allConnected,
+      spacing,
+      missingConnections: result.missingConnections
+    };
+
+    const isBetter = (bestResult === null)
+      || (candidate.allConnected && !bestResult.allConnected)
+      || (candidate.allConnected === bestResult.allConnected && lengthSum < bestLength);
+
+    if (isBetter) {
+      bestResult = candidate;
+      bestLength = lengthSum;
+    }
+  }
+
+  return bestResult || {
+    layout: generateLayout(locations),
+    connectors: [],
+    connectorRooms: [],
+    allConnected: false,
+    spacing: 0,
+    missingConnections: []
+  };
+}
+
+// ============================================================================
+// UTILITY: Normalize location name for comparison
+// ============================================================================
+
+export function normalizeLocationName(name: string): string {
+  return String(name || '')
+    .toLowerCase()
+    .replace(/[_\s]+/g, '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+}
+
+// ============================================================================
+// UTILITY: Build location graph from scenario
+// ============================================================================
+
+export interface LocationMeta {
+  name?: string;
+  description?: string;
+  connections?: string[];
+  dangers?: string[];
+  secrets?: string[];
+  npcs?: string[];
+  discovered?: boolean;
+}
+
+export function buildLocationGraphFromScenario(scenario: {
+  locations?: Record<string, LocationMeta>;
+}): {
+  locations: LocationGraph;
+  displayNames: Record<string, string>;
+  meta: Record<string, LocationMeta>;
+} {
+  const rawLocations = scenario?.locations || {};
+  const normalizedMap = new Map<string, string>();
+  const displayNames: Record<string, string> = {};
+  const meta: Record<string, LocationMeta> = {};
+
+  for (const [key, loc] of Object.entries(rawLocations)) {
+    const displayName = loc?.name || key;
+    const normalized = normalizeLocationName(displayName);
+    normalizedMap.set(normalizeLocationName(key), normalized);
+    normalizedMap.set(normalized, normalized);
+    displayNames[normalized] = displayName;
+    meta[normalized] = loc || {};
+  }
+
+  const locations: LocationGraph = {};
+  for (const [key, loc] of Object.entries(rawLocations)) {
+    const displayName = loc?.name || key;
+    const normalized = normalizeLocationName(displayName);
+    const connections = Array.isArray(loc?.connections) ? loc.connections : [];
+    const normalizedConnections: string[] = [];
+    for (const conn of connections) {
+      const normalizedConn = normalizedMap.get(normalizeLocationName(conn)) || normalizeLocationName(conn);
+      if (normalizedConn && normalizedConn !== normalized) normalizedConnections.push(normalizedConn);
+    }
+    locations[normalized] = {
+      connections: Array.from(new Set(normalizedConnections))
+    };
+  }
+
+  return { locations, displayNames, meta };
+}


### PR DESCRIPTION
Replace list-based map modal with canvas-based spatial grid visualization:
- Add mapLayout.ts with room placement algorithm (hub detection, adjacency optimization, multi-attempt layout)
- Add connector routing with A* pathfinding between rooms
- Create MapCanvas component with canvas rendering (rooms, connectors, scanlines effect)
- Update MapModal to use fullscreen spatial map with legend
- Rooms sized based on connection count, visibility states (current/visited/adjacent/unknown)

https://claude.ai/code/session_016nvgFXpjPrfV2WDwAf1JYn