### PR TITLE
Add KO bug report button to death screen

### DIFF
--- a/src/ui/components/BugReportButton.tsx
+++ b/src/ui/components/BugReportButton.tsx
@@ -86,22 +86,20 @@ export function BugReportButton({ entry }: BugReportButtonProps): JSX.Element {
         style={{
           fontFamily: 'var(--font-mono)',
           fontSize: '9px',
-          color: 'var(--text-system)',
+          color: 'var(--danger)',
           background: 'none',
           border: 'none',
           cursor: 'pointer',
           padding: '0 2px',
           letterSpacing: '0.05em',
-          opacity: 0.5,
-          transition: 'opacity 150ms, color 150ms',
+          opacity: 0.7,
+          transition: 'opacity 150ms',
         }}
         onMouseEnter={e => {
           (e.currentTarget as HTMLButtonElement).style.opacity = '1';
-          (e.currentTarget as HTMLButtonElement).style.color = 'var(--danger)';
         }}
         onMouseLeave={e => {
-          (e.currentTarget as HTMLButtonElement).style.opacity = '0.5';
-          (e.currentTarget as HTMLButtonElement).style.color = 'var(--text-system)';
+          (e.currentTarget as HTMLButtonElement).style.opacity = '0.7';
         }}
       >
         KO

--- a/src/ui/screens/EndScreen.tsx
+++ b/src/ui/screens/EndScreen.tsx
@@ -132,7 +132,7 @@ export function EndScreen(): JSX.Element {
               gap: '6px',
               fontFamily: 'var(--font-mono)',
               fontSize: '10px',
-              color: 'var(--amber-dim)',
+              color: 'var(--danger)',
               justifyContent: 'center',
             }}
           >


### PR DESCRIPTION
## Summary
Added a bug report feature to the EndScreen that allows players to report suspicious deaths. When the game ends in defeat, a "Mort suspecte ?" (Suspicious death?) prompt appears with a button to submit a bug report containing the last turn's data.

## Changes
- Imported `BugReportButton` component for bug reporting functionality
- Extracted the last turn entry from turn history to pass to the bug report button
- Added a conditional UI section that displays only on defeat screens, showing:
  - A "Mort suspecte ?" (Suspicious death?) prompt
  - A `BugReportButton` component that captures the final turn data
  - Styled with monospace font, amber color, and proper spacing to match the existing UI

## Implementation Details
- The bug report section only renders when `!isVictory && lastEntry` conditions are met
- The last turn entry is safely extracted with a null check: `turnHistory.length > 0 ? turnHistory[turnHistory.length - 1]! : null`
- The UI uses consistent styling with existing components (flexbox layout, CSS variables for colors/fonts, 320px max-width constraint)
- Positioned before the navigation buttons for logical flow on the defeat screen

https://claude.ai/code/session_01Fo8enUBJA1dJMXnW9TdssX