### PR TITLE
Update feature token color from amber to cyan

### DIFF
--- a/src/ui/components/NarrativePanel.tsx
+++ b/src/ui/components/NarrativePanel.tsx
@@ -14,7 +14,7 @@ import { BugReportButton } from './BugReportButton';
 
 const TOKEN_COLORS: Record<string, string> = {
   location: 'var(--amber-glow)',
-  feature: 'var(--amber-mid)',
+  feature: 'var(--cyan)',
   item: 'var(--success)',
   npc: 'var(--warning)',
   exit: 'var(--text-secondary)',

--- a/src/ui/styles/globals.css
+++ b/src/ui/styles/globals.css
@@ -18,6 +18,8 @@
   --amber-dim: #805500;
   --amber-bg: #1A1200;
 
+  --cyan: #00CFCF;
+
   --success: #00FF41;
   --success-dim: #00802A;
   --danger: #FF2020;


### PR DESCRIPTION
## Summary
Updated the color scheme for feature tokens in the narrative panel to use a new cyan color instead of the existing amber-mid color.

## Changes
- Added new `--cyan` CSS custom property (`#00CFCF`) to the global color palette
- Changed the `feature` token color in `NarrativePanel` from `var(--amber-mid)` to `var(--cyan)`

## Details
This change improves visual distinction for feature tokens by assigning them a dedicated cyan color rather than reusing the amber color palette. The new cyan color is defined as `#00CFCF` and provides better contrast and differentiation from location tokens (which use `--amber-glow`).

https://claude.ai/code/session_01Xr9D6U2BgdngwTs6hXihPg